### PR TITLE
临时修复因 API 端点分页机制导致版本列表获取不完整的问题

### DIFF
--- a/cleanroom/scripts/main.py
+++ b/cleanroom/scripts/main.py
@@ -4,7 +4,7 @@ import requests
 from pathlib import Path
 
 def get_releases():
-    url = "https://api.github.com/repos/CleanroomMC/Cleanroom/releases"
+    url = "https://api.github.com/repos/CleanroomMC/Cleanroom/releases?per_page=100"
     headers = {}
     
     # 检查 GH_TOKEN 环境变量


### PR DESCRIPTION
# 临时修复因 API 端点分页机制导致版本列表获取不完整的问题

<img width="818" height="508" alt="image" src="https://github.com/user-attachments/assets/868ceecc-cafe-4a31-ade6-c2d0b104c08f" />

api 端点默认每页 30 条记录，现在总版本数已经大于 30 个，因此当前的更新行为会导致只能获取最新的 30 版本。

现在已通过添加 `per_page` 参数修改 api 端点为每页获取 100 条记录用于临时解版本列表获取不完整的问题。

https://github.com/neveler/metadata/commit/c3d76dac2d6d19729a4dbee6c7e7b6ea68107d18#diff-eca8529f85dee4cfd00c5b3a2a5f51397edb503184849601a01b2e8d95ec5e85
