### PR TITLE
增量更新 cleanroom

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -53,8 +53,6 @@ jobs:
           cd ./cleanroom/scripts
           python3 main.py
           mv index.json ../
-          rm -rf ../files
-          mv files ../
           cd ../..
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cleanroom/scripts/main.py
+++ b/cleanroom/scripts/main.py
@@ -37,7 +37,8 @@ def save_index(releases):
 def download_files(releases):
     # 创建 files 目录
     current_dir = Path(__file__).parent
-    files_dir = current_dir / "files"
+    parent_dir = current_dir.parent
+    files_dir = parent_dir / "files"
     files_dir.mkdir(exist_ok=True)
     
     for release in releases:


### PR DESCRIPTION
# 增量更新 cleanroom

https://github.com/neveler/metadata/commit/fbd1a164c3266774a678761b407674a1c6ccfd2c

https://github.com/neveler/metadata/actions/runs/20550877790/job/59028285339

```log
跳过已存在的文件: cleanroom-0.3.32-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.31-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.30-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.29-alpha-installer.jar
正在下载: cleanroom-0.3.28-alpha-installer.jar
下载完成: cleanroom-0.3.28-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.27-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.26-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.25-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.24-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.23-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.22-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.21-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.20-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.19-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.17-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.16-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.15-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.14-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.13-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.11-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.10-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.9-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.8-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.7-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.6-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.5-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.4-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.3-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.2-alpha-installer.jar
跳过已存在的文件: cleanroom-0.3.1-alpha-installer.jar
```