### PR TITLE
优化工作流

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,12 +13,11 @@ permissions:
   contents: write
 
 jobs:
-  update_forge-metadata:
+  update-metadata:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Set time
-        shell: bash
         run: sudo timedatectl set-timezone 'Asia/Shanghai'
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -29,8 +28,6 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install xmljson requests python-dateutil
       - name: Fetch forge-metadata changes
-        id: fetch_forge_changes
-        shell: bash
         run: |
           cd ./forge/scripts
           python3 xml_to_json.py
@@ -38,28 +35,20 @@ jobs:
           python3 install.py
           python3 gettime.py
           mv index.json ../
-          cd ../..
       - name: Fetch cleanroom-metadata changes
-        id: fetch_cleanroom_changes
-        shell: bash
         run: |
           cd ./cleanroom/scripts
           python3 main.py
           mv index.json ../
-          cd ../..
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch optifine-metadata changes
-        id: fetch_optifine_changes
-        shell: bash
         run: |
           cd ./optifine/scripts
           python3 main.py
           python3 converter.py
           mv index.json ../
-          cd ../..
       - name: Commit changes
-        shell: bash
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -76,3 +65,21 @@ jobs:
           GitHub Action: https://github.com/${{ github.repository }}/actions/runs/$GITHUB_RUN_ID
           "
           git push origin
+      - name: Build Pages
+        run: |
+          mkdir -p /home/runner/gh-pages/{cleanroom,forge,optifine}
+          mv ./cleanroom/index.json /home/runner/gh-pages/cleanroom/
+          mv ./cleanroom/files /home/runner/gh-pages/cleanroom/
+          mv ./fmllibs /home/runner/gh-pages/
+          mv ./forge/index.json /home/runner/gh-pages/forge/
+          mv ./optifine/index.json /home/runner/gh-pages/optifine/
+      - name: Upload Pages
+        id: upload-pages
+        uses: actions/upload-pages-artifact@v4
+        with:
+          name: github-pages
+          path: /home/runner/gh-pages
+      - name: Deploy Pages
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -60,6 +60,7 @@ jobs:
 
           if git diff --cached --quiet; then
             echo "No changes detected, skip commit and push."
+            echo "SKIP=true" >> $GITHUB_ENV
             exit 0
           fi
 
@@ -69,6 +70,7 @@ jobs:
           "
           git push origin
       - name: Build Pages
+        if: ${{ env.SKIP != 'true' }}
         run: |
           mkdir -p /home/runner/gh-pages/{cleanroom,forge,optifine}
           mv ./cleanroom/index.json /home/runner/gh-pages/cleanroom/
@@ -77,11 +79,13 @@ jobs:
           mv ./forge/index.json /home/runner/gh-pages/forge/
           mv ./optifine/index.json /home/runner/gh-pages/optifine/
       - name: Upload Pages
+        if: ${{ env.SKIP != 'true' }}
         uses: actions/upload-pages-artifact@v4
         with:
           name: github-pages
           path: /home/runner/gh-pages
       - name: Deploy Pages
+        if: ${{ env.SKIP != 'true' }}
         id: deployment
         uses: actions/deploy-pages@v4
         with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   update-metadata:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
       - name: Set time
@@ -74,12 +77,12 @@ jobs:
           mv ./forge/index.json /home/runner/gh-pages/forge/
           mv ./optifine/index.json /home/runner/gh-pages/optifine/
       - name: Upload Pages
-        id: upload-pages
         uses: actions/upload-pages-artifact@v4
         with:
           name: github-pages
           path: /home/runner/gh-pages
       - name: Deploy Pages
+        id: deployment
         uses: actions/deploy-pages@v4
         with:
           artifact_name: github-pages

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,7 +10,9 @@ on:
       - '**.py'
 
 permissions:
+  pages: write
   contents: write
+  id-token: write
 
 jobs:
   update-metadata:


### PR DESCRIPTION
# 优化工作流

> [!WARNING]
> 需要修改 Github Pages 的部署方式为 Actions

1. 去除非必需的 `shell: bash`
2. 去除步骤结尾无意义的 `cd`
3. 使用 GitHub Actions 部署 GitHub Pages，避免将非必要文件（如脚本文件）部署到 GitHub Pages
